### PR TITLE
fix path to temp test file at 'test_read_csv'

### DIFF
--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -158,11 +158,10 @@ def test_explain(con, alltypes):
 @pytest.mark.parametrize(
     'filename',
     [
-        "/omnisci/test_read_csv.csv",
-        pathlib.Path("/omnisci/test_read_csv.csv"),
+        "/tmp/test_read_csv.csv",
+        pathlib.Path("/tmp/test_read_csv.csv"),
     ],
 )
-@pytest.mark.skip("don't use full path")
 def test_read_csv(con, temp_table, filename):
     schema = ibis.schema(
         [

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -158,6 +158,9 @@ def test_explain(con, alltypes):
 @pytest.mark.parametrize(
     'filename',
     [
+        # FIXME: that path is only vaild for Linux-like systems,
+        # should generalize path to temp directory that would be
+        # valid at any platform (dependends on OS where omnisci is running)
         "/tmp/test_read_csv.csv",
         pathlib.Path("/tmp/test_read_csv.csv"),
     ],


### PR DESCRIPTION
Because test file used as temporary, it's rational to store it at `/tmp` folder, which is always exists (unlike `/omnisci`)